### PR TITLE
TypeError into time_elapsed() function

### DIFF
--- a/piston/post.py
+++ b/piston/post.py
@@ -1,6 +1,7 @@
 import json
 import re
 from datetime import datetime
+from dateutil.parser import parse
 
 from funcy import walk_values
 from piston.instance import shared_steem_instance
@@ -234,7 +235,9 @@ class Post(dict):
     def time_elapsed(self):
         """Return a timedelta on how old the post is.
         """
-        return datetime.utcnow() - datetime.strptime(self['created'], '%Y-%m-%dT%H:%M:%S')
+        # Note: Instead of parse() function from dateutil module
+        # we can use the parse_time() function from utils.py:221
+        return datetime.utcnow() - parse(self['created'])
 
     def is_main_post(self):
         """ Retuns True if main post, and False if this is a comment (reply).

--- a/piston/post.py
+++ b/piston/post.py
@@ -234,7 +234,7 @@ class Post(dict):
     def time_elapsed(self):
         """Return a timedelta on how old the post is.
         """
-        return datetime.utcnow() - self['created']
+        return datetime.utcnow() - datetime.strptime(self['created'], '%Y-%m-%dT%H:%M:%S')
 
     def is_main_post(self):
         """ Retuns True if main post, and False if this is a comment (reply).

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "python-frontmatter>=0.2.1",
         "pycrypto>=2.6.1",
         "funcy",
+        "python-dateutil>=2.6.1",
         # "python-dateutil",
         # "secp256k1==0.13.2"
     ],


### PR DESCRIPTION
Fixed TypeError issue in time_elapsed() function. The following action: self[created] returned a string, not datetime object. Performed convert string to datetime using strptime() function.